### PR TITLE
added cast to unicode for function options. 

### DIFF
--- a/doctestmagic.py
+++ b/doctestmagic.py
@@ -98,7 +98,7 @@ class DoctestMagic(Magics):
         verbose = args.verbose
         name = args.name
         try:
-            optionflags = eval(args.options)
+            optionflags = eval(unicode(args.options))
         except AttributeError, e:
             if args.options.startswith('doctest.'):
                 raise AttributeError(str(e).replace(


### PR DESCRIPTION
calling 
`%doctest some_func`
without any options resulted in TypeError for me, as no options seems to be represented by the int 0 which cant be evaluated by `eval()`
